### PR TITLE
fix: dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: weekly
     reviewers:
       - Conni2461
-    auto-merge: true


### PR DESCRIPTION
doesn't like auto-merge

https://github.com/helsinki-systems/harmonia/runs/7672106870