### PR TITLE
module.nix: pass pkgs to harmonia package

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -5,7 +5,7 @@ let
   format = pkgs.formats.toml { };
   configFile = format.generate "harmonia.toml" cfg.settings;
 
-  harmonia = import ./. { };
+  harmonia = import ./. { inherit pkgs; };
 in
 {
   options = {


### PR DESCRIPTION
Makes it usable from flakes.