### PR TITLE
Remove nix.allowedUsers to prevent unintended side effects

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -75,7 +75,5 @@ in
       };
       groups.harmonia = { };
     };
-
-    nix.allowedUsers = [ "harmonia" ];
   };
 }


### PR DESCRIPTION
``nix.allowedUsers`` defaults to ``*`` and limiting it to only harmonia has side effects when used with other services on the same host/vm.