### PR TITLE
doc(libnixstore): rustdoc for Drv, PathInfo, and two functions

### DIFF
--- a/libnixstore/src/lib.rs
+++ b/libnixstore/src/lib.rs
@@ -97,7 +97,7 @@ fn string_to_opt(v: String) -> Option<String> {
 pub struct PathInfo {
     /// The deriver of this path, if one exists.
     pub drv: Option<String>,
-    /// The result executing `nix-store --dump` on this path and hashing its output.  This string
+    /// The result of executing `nix-store --dump` on this path and hashing its output.  This string
     /// can be either a hexidecimal or base32 string, depending on the arguments passed to
     /// `query_path_info()`.
     pub narhash: String,

--- a/libnixstore/src/lib.rs
+++ b/libnixstore/src/lib.rs
@@ -108,11 +108,11 @@ pub struct PathInfo {
     pub size: usize,
     /// The store paths referenced by this path.
     pub refs: Vec<String>,
-    /// The signatures on this store path; "note: not necessarily verified"
+    /// The signatures on this store path; "note: not necessarily verified".
     pub sigs: Vec<String>,
     /// Indicates if this store-path is input-addressed (`None`) or content-addressed (`Some`).  The
     /// `String` value contains the content hash as well as "some other bits of data"; see
-    /// `path-info.hh` for details
+    /// `path-info.hh` for details.
     pub ca: Option<String>,
 }
 
@@ -120,12 +120,12 @@ pub struct Drv {
     /// The mapping from output names to to realised outpaths, or `None` for outputs which are not
     /// realised in this store.
     pub outputs: std::collections::HashMap<String, Option<String>>,
-    /// The paths of this derivation's input derivations
+    /// The paths of this derivation's input derivations.
     pub input_drvs: Vec<String>,
     /// The paths of this derivation's input sources; these are files which enter the nix store as a
     /// result of `nix-store --add` or a `./path` reference.
     pub input_srcs: Vec<String>,
-    /// The `system` field of the derivation
+    /// The `system` field of the derivation.
     pub platform: String,
     /// The `builder` field of the derivation, which is executed in order to realise the
     /// derivation's outputs.


### PR DESCRIPTION
Hey, thanks so much for writing this awesome crate!  It was exactly
what I needed and "just worked" on the first try.

This PR adds rustdoc comments for the fields of `Drv` and
`PathInfo`, as well as the `base32` argument to `query_path_info()`
and the `include_outputs` argument to `compute_fs_closure()`.