### PR TITLE
Add Cache-Control headers to control caching of responses.

### DIFF
--- a/harmonia/src/main.rs
+++ b/harmonia/src/main.rs
@@ -341,7 +341,7 @@ async fn get_build_log(drv: web::Path<String>) -> Result<HttpResponse, Box<dyn E
 async fn get_nar_list(hash: web::Path<String>) -> Result<HttpResponse, Box<dyn Error>> {
     let store_path = some_or_404!(nixhash(&hash));
     Ok(HttpResponse::Ok()
-        .insert_header(cache_control_no_store())
+        .insert_header(cache_control_max_age_1y())
         .json(libnixstore::get_nar_list(&store_path)?))
 }
 


### PR DESCRIPTION
In order to control the caching done by reverse proxies sitting in front of harmonia, we need to include `Cache-Control` headers in the HTTP responses. Without these headers, most reverse proxies will not automatically cache responses.

We also set the caching policy to `no-store` for missing store paths such that clients do not get served a cached 404 response for newly created store paths.

We allow caching `.narinfo` responses for 1 day, since they can change (for instance if the URL of the NAR files on the server changes). NAR files should not change, and so we allow caching them for 1 year.