### PR TITLE
chore(tests): update attrnames to mute nixos warnings

### DIFF
--- a/tests/t00-simple.nix
+++ b/tests/t00-simple.nix
@@ -21,8 +21,8 @@ in
 
     client01 = { config, pkgs, lib, ... }:
       {
-        nix.requireSignedBinaryCaches = false;
-        nix.binaryCaches = lib.mkForce [ "http://harmonia:5000" ];
+        nix.settings.require-sigs = false;
+        nix.settings.substituters = lib.mkForce [ "http://harmonia:5000" ];
         nix.extraOptions = ''
           experimental-features = nix-command
         '';

--- a/tests/t01-signing.nix
+++ b/tests/t01-signing.nix
@@ -35,7 +35,7 @@ in
     client01 = { config, pkgs, lib, ... }:
       {
         environment.systemPackages = [ copyScript ];
-        nix.binaryCaches = lib.mkForce [ "http://harmonia:5000" ];
+        nix.settings.substituters = lib.mkForce [ "http://harmonia:5000" ];
         nix.extraOptions = ''
           experimental-features = nix-command
         '';

--- a/tests/t02-varnish.nix
+++ b/tests/t02-varnish.nix
@@ -33,8 +33,8 @@ in
 
     client01 = { config, pkgs, lib, ... }:
       {
-        nix.requireSignedBinaryCaches = false;
-        nix.binaryCaches = lib.mkForce [ "http://harmonia" ];
+        nix.settings.require-sigs = false;
+        nix.settings.substituters = lib.mkForce [ "http://harmonia" ];
         nix.extraOptions = ''
           experimental-features = nix-command
         '';


### PR DESCRIPTION
Prior to this commit, the test suite emits the following warnings (using nixpkgs ~22.11):

```
trace: warning: The option `nix.requireSignedBinaryCaches' defined in `makeTest parameters' has been renamed to `nix.settings.require-sigs'.
trace: warning: The option `nix.binaryCaches' defined in `makeTest parameters' has been renamed to `nix.settings.substituters'.
trace: warning: The option `nix.binaryCaches' defined in `makeTest parameters' has been renamed to `nix.settings.substituters'.
trace: warning: The option `nix.requireSignedBinaryCaches' defined in `makeTest parameters' has been renamed to `nix.settings.require-sigs'.
trace: warning: The option `nix.binaryCaches' defined in `makeTest parameters' has been renamed to `nix.settings.substituters'.
```

This commit updates the attrnames to mute the warnings.